### PR TITLE
Removed DAS notifications NuGet package - no longer required.

### DIFF
--- a/src/Sfa.Tl.Matching.Infrastructure/Sfa.Tl.Matching.Infrastructure.csproj
+++ b/src/Sfa.Tl.Matching.Infrastructure/Sfa.Tl.Matching.Infrastructure.csproj
@@ -14,8 +14,4 @@
     <Folder Include="Interfaces\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="SFA.DAS.Notifications.Api.Client" Version="2.1.19" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Missed this when checking Ewan's changes.