### PR TITLE
Add setting for system id passed to Notifications API

### DIFF
--- a/config/Sfa.Tl.Matching.schema.json
+++ b/config/Sfa.Tl.Matching.schema.json
@@ -74,7 +74,7 @@
       "type": "object"
     },
     "NotificationsSystemId": {
-      "type": "boolean",
+      "type": "string",
       "environmentVariable": "NotificationsSystemId"
     },
     "SendEmailEnabled": {

--- a/config/Sfa.Tl.Matching.schema.json
+++ b/config/Sfa.Tl.Matching.schema.json
@@ -73,6 +73,10 @@
       ],
       "type": "object"
     },
+    "NotificationsSystemId": {
+      "type": "boolean",
+      "environmentVariable": "NotificationsSystemId"
+    },
     "SendEmailEnabled": {
       "type": "boolean",
       "environmentVariable": "SendEmailEnabled"

--- a/src/Sfa.Tl.Matching.Application.UnitTests/Services/Email/When_EmailService_Is_Called_To_Send_Email.cs
+++ b/src/Sfa.Tl.Matching.Application.UnitTests/Services/Email/When_EmailService_Is_Called_To_Send_Email.cs
@@ -26,7 +26,8 @@ namespace Sfa.Tl.Matching.Application.UnitTests.Services.Email
         {
             var configuration = new MatchingConfiguration
             {
-                SendEmailEnabled = true
+                SendEmailEnabled = true,
+                NotificationsSystemId = "TLevelsIndustryPlacement"
             };
 
             _notificationsApi = Substitute.For<INotificationsApi>();
@@ -36,7 +37,7 @@ namespace Sfa.Tl.Matching.Application.UnitTests.Services.Email
             var emailTemplate = new EmailTemplate
             {
                 Id = 1,
-                TemplateId = "TemplateId",
+                TemplateId = "1599768C-7D3D-43AB-8548-82A4E5349468",
                 TemplateName = "TemplateName"
             };
 
@@ -89,9 +90,15 @@ namespace Sfa.Tl.Matching.Application.UnitTests.Services.Email
         }
 
         [Fact]
-        public void Then_NotificationsApi_SendEmail_Is_Called_With_SystemId_From_EmailService()
+        public void Then_NotificationsApi_SendEmail_Is_Called_With_Template_Id()
         {
-            _notificationsApi.Received(1).SendEmail(Arg.Is<SFA.DAS.Notifications.Api.Types.Email>(e => e.SystemId == EmailService.SystemId));
+            _notificationsApi.Received(1).SendEmail(Arg.Is<SFA.DAS.Notifications.Api.Types.Email>(e => e.TemplateId == "1599768C-7D3D-43AB-8548-82A4E5349468"));
+        }
+
+        [Fact]
+        public void Then_NotificationsApi_SendEmail_Is_Called_With_SystemId_From_Configuration()
+        {
+            _notificationsApi.Received(1).SendEmail(Arg.Is<SFA.DAS.Notifications.Api.Types.Email>(e => e.SystemId == "TLevelsIndustryPlacement"));
         }
 
         [Fact]

--- a/src/Sfa.Tl.Matching.Application/Configuration/MatchingConfiguration.cs
+++ b/src/Sfa.Tl.Matching.Application/Configuration/MatchingConfiguration.cs
@@ -14,6 +14,8 @@ namespace Sfa.Tl.Matching.Application.Configuration
 
         public NotificationsApiClientConfiguration NotificationsApiClientConfiguration { get; set; }
 
+        public string NotificationsSystemId { get; set; }
+
         public bool SendEmailEnabled { get; set; }
 
         public string PostcodeRetrieverBaseUrl { get; set; }

--- a/src/Sfa.Tl.Matching.Application/Services/EmailService.cs
+++ b/src/Sfa.Tl.Matching.Application/Services/EmailService.cs
@@ -13,7 +13,6 @@ namespace Sfa.Tl.Matching.Application.Services
 {
     public class EmailService : IEmailService
     {
-        public const string SystemId = "TLevelsIndustryPlacement";
         public const string DefaultReplyToAddress = "DummyAddressOverriddenByNotificationsService"; //reply address is currently ignored by DAS Notifications
 
         private readonly MatchingConfiguration _configuration;
@@ -63,12 +62,12 @@ namespace Sfa.Tl.Matching.Application.Services
             {
                 _logger.LogInformation($"Sending {templateName} email to {recipient}");
 
-                await SendEmailViaNotificationsApi(recipient, subject, templateId, personalisationTokens, replyToAddress);
+                await SendEmailViaNotificationsApi(recipient, subject, templateId, _configuration.NotificationsSystemId, personalisationTokens, replyToAddress);
             }
         }
 
-        private async Task SendEmailViaNotificationsApi(string recipient, string subject, string templateId,
-            IDictionary<string, string> personalisationTokens, string replyToAddress)
+        private async Task SendEmailViaNotificationsApi(string recipient, string subject, string templateId, 
+            string systemId, IDictionary<string, string> personalisationTokens, string replyToAddress)
         {
             var email = new Email
             {
@@ -76,7 +75,7 @@ namespace Sfa.Tl.Matching.Application.Services
                 TemplateId = templateId,
                 ReplyToAddress = replyToAddress,
                 Subject = subject,
-                SystemId = SystemId,
+                SystemId = systemId,
                 Tokens = (Dictionary<string, string>)personalisationTokens
             };
 


### PR DESCRIPTION
Add NotificationsSystemId variable in build and use it to set SystemId passed to DAS Notifications. Allows us to continue using DAS emails until email templates are updated for T-Levels.