### PR TITLE
Increase bank holiday name length

### DIFF
--- a/src/Sfa.Tl.Matching.Database/Tables/BankHoliday.sql
+++ b/src/Sfa.Tl.Matching.Database/Tables/BankHoliday.sql
@@ -2,7 +2,7 @@
 (
 	[Id] INT NOT NULL IDENTITY(1,1), 
 	[Date] DATE NOT NULL, 
-	[Title] NVARCHAR(50) NOT NULL,
+	[Title] NVARCHAR(100) NOT NULL,
 	[CreatedOn] DATETIME2 NOT NULL DEFAULT getutcdate(), 
 	[CreatedBy] NVARCHAR(50) NULL, 
 	[ModifiedOn] DATETIME2 NULL, 


### PR DESCRIPTION
For ticket TLWP-1820 - BUG: Error inserting BankHoliday data into the database
 - broken by 'Bank Holiday for the State Funeral of Queen Elizabeth II'